### PR TITLE
experiment icon changes from " public template " to  "public experiment"

### DIFF
--- a/frontend/src/app/features/experiments/pages/template-detail/template-detail.html
+++ b/frontend/src/app/features/experiments/pages/template-detail/template-detail.html
@@ -16,7 +16,7 @@
   <section class="head">
     <div class="title-wrap">
       <h1 class="title">{{ tpl()?.name }}</h1>
-      <mat-icon class="vis" [matTooltip]="isPublic() ? 'Public template' : 'Private template'">
+      <mat-icon class="vis" [matTooltip]="isPublic() ? 'Public experiment' : 'Private experiment'">
         {{ isPublic() ? 'public' : 'lock' }}
       </mat-icon>
     </div>


### PR DESCRIPTION
#57 Incorrect hover text for icon
There is an incorrect hover tooltip for the experiment visibility icon. It currently displays "Public template", which is misleading because the icon represents an experiment, not a template.

This can be reproduced by navigating to Experiments, opening any experiment (e.g., "Summarization experiment"), and hovering over the visibility (globe) icon next to the experiment title. The tooltip shows "Public template".
<img width="1415" height="795" alt="Screenshot 2026-03-01 010911" src="https://github.com/user-attachments/assets/d2e2312b-a537-4ccb-a871-6f42dabe135d" />



The expected behavior is that the tooltip reflects the experiment’s visibility status, such as "Public experiment" or "Private experiment".

This appears to be caused by template-related tooltip text being reused for experiments.

